### PR TITLE
Ensure that bindgen recognizes booleans as such

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,12 @@ use std::env;
 use std::io::{self, Write};
 use std::path::PathBuf;
 
-const CDIO_HEADER: &str = "#include <cdio/cdio.h>
+// libcdio uses a homegrown boolean type for versions < 2.1.1.
+// The homegrown boolean type is not recognized by bindgen.
+// This would result in different code gen for versions < 2.1.1 and versions >= 2.1.1.
+// To prevent this, we include stdbool.h ourselves, which suppresses the homegrown boolean type.
+const CDIO_HEADER: &str = "#include <stdbool.h>
+#include <cdio/cdio.h>
 #include <cdio/cd_types.h>
 #include <cdio/logging.h>
 #include <cdio/mmc_cmds.h>


### PR DESCRIPTION
libcdio used a homegrown boolean type for versions < 2.1.1.
Starting with version 2.1.1, they switched to the standard boolean type from `stdbool.h`.

Since bindgen only recognizes the bool type from `stdbool.h`, this results in different code being generated, for example for the `cdtext_select_language` function:

```diff
  unsafe extern "C" {
      // < 2.1.1
-     pub fn cdtext_select_language(p_cdtext: *mut cdtext_t, language: cdtext_lang_t) -> ::std::os::raw::c_uchar;
      // >= 2.1.1
+     pub fn cdtext_select_language(p_cdtext: *mut cdtext_t, language: cdtext_lang_t) -> bool;
  }
```

Importing `stdbool.h` ourselves ensures that libcdio always uses the same bool type.