### PR TITLE
Use pkgconfig to search for system libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "GPL-3.0+"
 
 [build-dependencies]
 bindgen = "0.72"
+system-deps = "7"
 
 [features]
 default = ["iso9660", "udf"]
@@ -20,6 +21,13 @@ iso9660 = []
 udf = []
 cdda = []
 paranoia = ["cdda"]
+
+[package.metadata.system-deps]
+libcdio = "0"
+libiso9660 = { version = "0", feature = "iso9660" }
+libudf = { version = "0", feature = "udf" }
+libcdio_cdda = { version = "0", feature = "cdda" }
+libcdio_paranoia = { version = "0", feature = "paranoia" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -8,9 +8,37 @@ Native bindings to the libcdio and libcdio-paranoia libraries
 [libcdio homepage](https://www.gnu.org/software/libcdio/)  
 [libcdio documentation](https://www.gnu.org/software/libcdio/libcdio.html)
 
-# Prerequisites
+# Building
+
+## Prerequisites
 
 You need to have libcdio and its headers installed in order to build this crate.
+
+pkg-config is also required to build this crate normally, though this requirement can be avoided by setting the following environment variables:
+
+| Feature    | Environment variables                                                                         |
+| ---------- | --------------------------------------------------------------------------------------------- |
+| none       | `SYSTEM_DEPS_LIBCDIO_NO_PKG_CONFIG=1 SYSTEM_DEPS_LIBCDIO_LIB=cdio`                            |
+| `iso9660`  | `SYSTEM_DEPS_LIBISO9660_NO_PKG_CONFIG=1 SYSTEM_DEPS_LIBISO9660_LIB=iso9660`                   |
+| `udf`      | `SYSTEM_DEPS_LIBUDF_NO_PKG_CONFIG=1 SYSTEM_DEPS_LIBUDF_LIB=udf`                               |
+| `cdda`     | `SYSTEM_DEPS_LIBCDIO_CDDA_NO_PKG_CONFIG=1 SYSTEM_DEPS_LIBCDIO_CDDA_LIB=cdio_cdda`             |
+| `paranoia` | `SYSTEM_DEPS_LIBCDIO_PARANOIA_NO_PKG_CONFIG=1 SYSTEM_DEPS_LIBCDIO_PARANOIA_LIB=cdio_paranoia` |
+
+## Overriding the libcdio library
+
+To control the libcdio library used when building this crate, set the `PKG_CONFIG_PATH` environment variable to the path of the directory containing pkg-config files for the correct library.
+Alternatively, set the the following environment variables, depending on which features you have enabled:
+
+| Feature    | Library path                                 | Include path                           |
+| ---------- | -------------------------------------------- | -------------------------------------- |
+| none       | `SYSTEM_DEPS_LIBCDIO_SEARCH_NATIVE`          | `SYSTEM_DEPS_LIBCDIO_INCLUDE`          |
+| `iso9660`  | `SYSTEM_DEPS_LIBISO9660_SEARCH_NATIVE`       | `SYSTEM_DEPS_LIBISO9660_INCLUDE`       |
+| `udf`      | `SYSTEM_DEPS_LIBUDF_SEARCH_NATIVE`           | `SYSTEM_DEPS_LIBUDF_INCLUDE`           |
+| `cdda`     | `SYSTEM_DEPS_LIBCDIO_CDDA_SEARCH_NATIVE`     | `SYSTEM_DEPS_LIBCDIO_CDDA_INCLUDE`     |
+| `paranoia` | `SYSTEM_DEPS_LIBCDIO_PARANOIA_SEARCH_NATIVE` | `SYSTEM_DEPS_LIBCDIO_PARANOIA_INCLUDE` |
+
+Variables in the "Library path" column should be set to the path of the directory containing the library, and variables in the "Include path" column should be set to the path of the directory containing the `cdio` header directory.
+See the [system-deps documentation](https://docs.rs/system-deps/7/system_deps/) for more information.
 
 # Usage
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::io::{self, Write};
 use std::path::PathBuf;
 
 // libcdio uses a homegrown boolean type for versions < 2.1.1.
@@ -37,26 +36,11 @@ const HEADERS: &[&str] = &[
     PARANOIA_HEADER,
 ];
 
-const LINK_LIBS: &[&str] = &[
-    "cdio",
-    #[cfg(feature = "iso9660")]
-    "iso9660",
-    #[cfg(feature = "udf")]
-    "udf",
-    #[cfg(feature = "cdda")]
-    "cdio_cdda",
-    #[cfg(feature = "paranoia")]
-    "cdio_paranoia",
-];
-
 fn main() {
-    let mut stdout = io::stdout().lock();
-    for lib in LINK_LIBS {
-        for s in [b"cargo:rustc-link-lib=", lib.as_bytes(), b"\n"] {
-            stdout.write_all(s).unwrap();
-        }
+    if let Err(s) = system_deps::Config::new().probe() {
+        println!("cargo:warning={s}");
+        std::process::exit(1);
     }
-    drop(stdout);
 
     let headers = HEADERS.join("");
     let bindings = bindgen::Builder::default()

--- a/examples/tracks.rs
+++ b/examples/tracks.rs
@@ -5,12 +5,12 @@ use std::process;
 use std::ptr;
 
 use libcdio_sys::{
-    cdio_destroy, cdio_get_disc_last_lsn, cdio_get_first_track_num, cdio_get_num_tracks,
-    cdio_get_track_lsn, cdio_open,
+    CDIO_INVALID_LSN, CdIo_t, cdio_track_enums_CDIO_CDROM_LEADOUT_TRACK,
+    driver_id_t_DRIVER_UNKNOWN, lsn_t, track_t,
 };
 use libcdio_sys::{
-    cdio_track_enums_CDIO_CDROM_LEADOUT_TRACK, driver_id_t_DRIVER_UNKNOWN, lsn_t, track_t, CdIo_t,
-    CDIO_INVALID_LSN,
+    cdio_destroy, cdio_get_disc_last_lsn, cdio_get_first_track_num, cdio_get_num_tracks,
+    cdio_get_track_lsn, cdio_open,
 };
 
 fn main() {


### PR DESCRIPTION
I am using the system-deps crate instead of using `pkg-config` directly. `system-deps` makes the system dependencies declarative by moving them to the Cargo.toml file. It also supports environment variables to override the system dependency should `pkg-config` be unavailable or undesired.

`system-deps` is also used by the GTK Rust bindings. For example: <https://github.com/gtk-rs/gtk4-rs/blob/main/gtk4/sys/build.rs>

This change is breaking because:
* `pkg-config` is now required to build this crate.
* It is now a build error (instead of a linking error) when one of the system libraries is missing.